### PR TITLE
chore: add bun.lockb file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 coverage
 *.local
 .env
+bun.lockb
 
 /cypress/videos/
 /cypress/screenshots/


### PR DESCRIPTION
I think the file `bun.lockb` should be in the `.gitignore.`